### PR TITLE
Fix warnings in digraph module with minimal changes

### DIFF
--- a/src/digraph.mbt
+++ b/src/digraph.mbt
@@ -18,7 +18,7 @@ pub(all) struct Tree {
 }
 
 ///|
-pub fn Edge::new(from~ : Int, to~ : Int, label~ : String = "") -> Edge {
+pub fn Edge::new(from~ : Int, to~ : Int, label? : String = "") -> Edge {
   { from, to, label }
 }
 

--- a/src/digraph_test.mbt
+++ b/src/digraph_test.mbt
@@ -5,7 +5,7 @@ enum Expr {
 }
 
 ///|
-fn eval_path(self : Expr) -> Digraph {
+fn Expr::eval_path(self : Expr) -> Digraph {
   let edges = []
   let nodes = []
   let mut cnt = 0
@@ -34,7 +34,7 @@ fn eval_path(self : Expr) -> Digraph {
 }
 
 ///|
-fn dump_ast(self : Expr) -> Digraph {
+fn Expr::dump_ast(self : Expr) -> Digraph {
   fn dfs(self : Expr) -> Tree {
     match self {
       Add(l, r) => Tree::{ label: "+", children: [dfs(l), dfs(r)] }
@@ -46,14 +46,14 @@ fn dump_ast(self : Expr) -> Digraph {
 }
 
 ///|
-test (t : @test.T) {
+test (t : @test.Test) {
   let expr = Add(Add(Lit(3), Lit(5)), Add(Lit(7), Lit(8)))
   t.writeln(expr.eval_path())
   t.snapshot(filename="expr.dot")
 }
 
 ///|
-test (t : @test.T) {
+test (t : @test.Test) {
   let expr = Add(Add(Lit(3), Lit(5)), Add(Lit(7), Lit(8)))
   t.writeln(expr.dump_ast())
   t.snapshot(filename="ast.dot")

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -1,0 +1,37 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/graphviz"
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct Digraph {
+  edges : Array[Edge]
+  nodes : Array[Node]
+}
+pub impl Show for Digraph
+
+pub(all) struct Edge {
+  from : Int
+  to : Int
+  label : String
+}
+pub fn Edge::new(from~ : Int, to~ : Int, label? : String) -> Self
+
+pub(all) struct Node {
+  id : Int
+  label : String
+}
+pub fn Node::new(id~ : Int, label~ : String) -> Self
+
+pub(all) struct Tree {
+  label : String
+  children : Array[Tree]
+}
+pub fn Tree::to_digraph(Self) -> Digraph
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

Fixed warnings in the digraph module while ensuring `moon check` works and `moon test` continues to function properly.

## Changes

- **src/digraph.mbt**: Updated to resolve warning (1 line changed)
- **src/digraph_test.mbt**: Modified test file to address warnings (4 lines changed)
- **src/pkg.generated.mbti**: Added generated type information file (37 lines added)

## Implementation Details

The changes were made with minimal modifications to eliminate warnings while maintaining functionality:
- Fixed warning issues in the main digraph implementation
- Updated corresponding test file to align with the changes
- Added the generated type information file that was missing

## Verification

- `moon check` now works without warnings
- `moon test` continues to pass
- No unnecessary package fixes were introduced

The solution follows the requirement to eliminate warnings with the smallest possible changeset while preserving all existing functionality.